### PR TITLE
feat: Allow inlining compile-time variables without curly braces

### DIFF
--- a/test-project/main.zog
+++ b/test-project/main.zog
@@ -1,6 +1,12 @@
 namespace example
 
-fn load() {
+fn &foo(something) {
+  return &something
+} 
+
+fn load(%text) {
   &value = 10
-  data modify storage example:load something set value &{&value}
+  data modify storage example:load something set value &value
+  scoreboard players set @s example.load &foo(12)
+  tellraw @a "%text"
 }

--- a/test-project/main.zog
+++ b/test-project/main.zog
@@ -1,8 +1,6 @@
 namespace example
 
 fn load() {
-  foo = 1
-  $bar = 2b
-  a = {a: 1, b: 2, c: foo}
-  b = [L; 1L, 2L, 3L, $bar]
+  &value = 10
+  data modify storage example:load something set value &{&value}
 }


### PR DESCRIPTION
This Zoglin code:
```
namespace example

fn load() {
  &value = 10
  data modify storage example:load something set value &value
}
```
Now compiles to this MCFunction:
```mcfunction
data modify storage example:load something set value 10
```